### PR TITLE
Redesigning filters to provide type safety for user-provided code

### DIFF
--- a/app/src/main/scala/vlthr/tee/core.scala
+++ b/app/src/main/scala/vlthr/tee/core.scala
@@ -288,11 +288,6 @@ object Value {
     }
   }
 
-  def makeValueTypeable[V](name: String)(f: PartialFunction[Any, Option[V]]) =
-    new Typeable[V] {
-      def cast(t: Any): Option[V] = f(t)
-      def describe = name
-    }
   implicit val intTypeable: Typeable[IntValue] =
     new Typeable[IntValue] {
       def cast(t: Any): Option[IntValue] = t match {
@@ -339,26 +334,47 @@ object Value {
 
       def describe: String = s"BooleanValue"
     }
-  // implicit val intTypeable: Typeable[IntValue] = makeValueTypeable("IntValue") {
-  // }
-  // implicit val mapTypeable: Typeable[MapValue] = makeValueTypeable("MapValue") {
-  //   case c: MapValue => Some(c)
-  //   case _ => None
-  // }
-  // implicit val listTypeable: Typeable[ListValue] = makeValueTypeable("ListValue") {
-  //   case c: ListValue => Some(c)
-  //   case _ => None
-  // }
-  // implicit val booleanTypeable: Typeable[BooleanValue] = makeValueTypeable("BooleanValue") {
-  //   case c: BooleanValue => Some(c)
-  //   case _ => None
-  // }
-  // implicit val stringTypeable: Typeable[StringValue] = makeValueTypeable("StringValue") {
-  //   case c: StringValue => Some(c)
-  //   case _ => None
-  // }
-  // implicit val nullTypeable: Typeable[NullValue] = makeValueTypeable("NullValue") {
-  //   case c: NullValue => Some(c)
-  //   case _ => None
-  // }
+  implicit val nullTypeable: Typeable[NullValue] =
+    new Typeable[NullValue] {
+      def cast(t: Any): Option[NullValue] = t match {
+        case v: NullValue => Some(v)
+        case _ => None
+      }
+
+      def describe: String = s"BooleanValue"
+    }
+
+  /** Temporary fix for implicits not being created for union types
+    */
+  implicit val listStrTypeable: Typeable[ListValue | StringValue] =
+    new Typeable[ListValue | StringValue] {
+      def cast(t: Any): Option[ListValue | StringValue] = t match {
+        case v: ListValue => Some(v)
+        case v: StringValue => Some(v)
+        case _ => None
+      }
+
+      def describe: String = s"BooleanValue"
+    }
+
+  /** Temporary fix for implicits not being created for union types
+    */
+  implicit val intStrTypeable: Typeable[IntValue | StringValue] =
+    new Typeable[IntValue | StringValue] {
+      def cast(t: Any): Option[IntValue | StringValue] = t match {
+        case v: IntValue => Some(v)
+        case v: StringValue => Some(v)
+        case _ => None
+      }
+
+      def describe: String = s"BooleanValue"
+    }
+
+  /** Not working
+    */
+  implicit def unionTypeable[A, B](implicit aType: Typeable[A], bType: Typeable[B]): Typeable[A | B] = new Typeable[A | B] {
+      def cast(t: Any): Option[A | B] = aType.cast(t).orElse(bType.cast(t))
+
+      def describe: String = s"${aType.describe} | ${bType.describe}"
+    }
 }

--- a/app/src/main/scala/vlthr/tee/core.scala
+++ b/app/src/main/scala/vlthr/tee/core.scala
@@ -293,28 +293,72 @@ object Value {
       def cast(t: Any): Option[V] = f(t)
       def describe = name
     }
-  implicit val intTypeable: Typeable[IntValue] = makeValueTypeable("IntValue") {
-    case c: IntValue => Some(c)
-    case _ => None
-  }
-  implicit val mapTypeable: Typeable[MapValue] = makeValueTypeable("MapValue") {
-    case c: MapValue => Some(c)
-    case _ => None
-  }
-  implicit val listTypeable: Typeable[ListValue] = makeValueTypeable("ListValue") {
-    case c: ListValue => Some(c)
-    case _ => None
-  }
-  implicit val booleanTypeable: Typeable[BooleanValue] = makeValueTypeable("BooleanValue") {
-    case c: BooleanValue => Some(c)
-    case _ => None
-  }
-  implicit val stringTypeable: Typeable[StringValue] = makeValueTypeable("StringValue") {
-    case c: StringValue => Some(c)
-    case _ => None
-  }
-  implicit val nullTypeable: Typeable[NullValue] = makeValueTypeable("NullValue") {
-    case c: NullValue => Some(c)
-    case _ => None
-  }
+  implicit val intTypeable: Typeable[IntValue] =
+    new Typeable[IntValue] {
+      def cast(t: Any): Option[IntValue] = t match {
+        case c: IntValue => Some(c)
+        case _ => None
+      }
+
+      def describe: String = s"IntValue"
+    }
+
+  implicit val stringTypeable: Typeable[StringValue] =
+    new Typeable[StringValue] {
+      def cast(t: Any): Option[StringValue] = t match {
+        case v: StringValue => Some(v)
+        case _ => None
+      }
+
+      def describe: String = s"StringValue"
+    }
+  implicit val mapTypeable: Typeable[MapValue] =
+    new Typeable[MapValue] {
+      def cast(t: Any): Option[MapValue] = t match {
+        case v: MapValue => Some(v)
+        case _ => None
+      }
+
+      def describe: String = s"MapValue"
+    }
+  implicit val listTypeable: Typeable[ListValue] =
+    new Typeable[ListValue] {
+      def cast(t: Any): Option[ListValue] = t match {
+        case v: ListValue => Some(v)
+        case _ => None
+      }
+
+      def describe: String = s"ListValue"
+    }
+  implicit val boolTypeable: Typeable[BooleanValue] =
+    new Typeable[BooleanValue] {
+      def cast(t: Any): Option[BooleanValue] = t match {
+        case v: BooleanValue => Some(v)
+        case _ => None
+      }
+
+      def describe: String = s"BooleanValue"
+    }
+  // implicit val intTypeable: Typeable[IntValue] = makeValueTypeable("IntValue") {
+  // }
+  // implicit val mapTypeable: Typeable[MapValue] = makeValueTypeable("MapValue") {
+  //   case c: MapValue => Some(c)
+  //   case _ => None
+  // }
+  // implicit val listTypeable: Typeable[ListValue] = makeValueTypeable("ListValue") {
+  //   case c: ListValue => Some(c)
+  //   case _ => None
+  // }
+  // implicit val booleanTypeable: Typeable[BooleanValue] = makeValueTypeable("BooleanValue") {
+  //   case c: BooleanValue => Some(c)
+  //   case _ => None
+  // }
+  // implicit val stringTypeable: Typeable[StringValue] = makeValueTypeable("StringValue") {
+  //   case c: StringValue => Some(c)
+  //   case _ => None
+  // }
+  // implicit val nullTypeable: Typeable[NullValue] = makeValueTypeable("NullValue") {
+  //   case c: NullValue => Some(c)
+  //   case _ => None
+  // }
 }

--- a/app/src/main/scala/vlthr/tee/error.scala
+++ b/app/src/main/scala/vlthr/tee/error.scala
@@ -33,6 +33,12 @@ package object Errors {
 
   def succeed[T](value: T): Validated[T] = Result.valid(value)
 
+  def imbueFragments[T](v: ValidatedFragment[T])(implicit pctx: ParseContext): Validated[T] = v match {
+    case v @ Valid(_) => v
+    case Invalids(errFragments) => Invalids(errFragments.map(_.imbue(pctx)))
+    case Invalid(errFragment) => Invalid(errFragment.imbue(pctx))
+  }
+
   def toTry[T](v: Validated[T]) = v match {
     case Valid(output) => Success(output)
     case Invalids(errs) => Failure(LiquidFailure(errs.toList))

--- a/app/src/main/scala/vlthr/tee/error.scala
+++ b/app/src/main/scala/vlthr/tee/error.scala
@@ -1,6 +1,7 @@
 package vlthr.tee.core
 import org.antlr.v4.runtime.{Recognizer, RecognitionException}
 import scala.util.{Try, Success, Failure}
+import vlthr.tee.util.Util
 import validation._
 import validation.Result.{Valid, Invalids, Invalid}
 import vlthr.tee.filters.Filter
@@ -95,7 +96,7 @@ package object Errors {
 
   case class UncaughtExceptionError(e: Throwable)(implicit pctx: ParseContext) extends Error(pctx) {
     def errorType = "Uncaught Exception"
-    def description = e.getMessage
+    def description = e.getMessage + "\n" + Util.getStackTrace(e)
   }
 
   case class InvalidKwArg(ext: Extension, key: String) extends ExtensionError {

--- a/app/src/main/scala/vlthr/tee/error.scala
+++ b/app/src/main/scala/vlthr/tee/error.scala
@@ -3,6 +3,7 @@ import org.antlr.v4.runtime.{Recognizer, RecognitionException}
 import scala.util.{Try, Success, Failure}
 import validation._
 import validation.Result.{Valid, Invalids, Invalid}
+import vlthr.tee.filters.Filter
 
 package object Errors {
   type Validated[A] = Result[Error, A]

--- a/app/src/main/scala/vlthr/tee/expr.scala
+++ b/app/src/main/scala/vlthr/tee/expr.scala
@@ -132,11 +132,11 @@ final case class VariableUseExpr(name: String)(implicit val pctx: ParseContext)
   }
 }
 
-final case class FilterExpr(expr: Expr,
-                            filter: Filter,
-                            args: List[Expr],
-                            kwargs: Map[String, Expr])(
-    implicit val pctx: ParseContext)
+final case class FilterExpr(
+    expr: Expr,
+    filter: Filter,
+    args: List[Expr],
+    kwargs: Map[String, Expr])(implicit val pctx: ParseContext)
     extends Expr {
   override def eval()(implicit ctx: Context) = {
     val exprVal = expr.eval()

--- a/app/src/main/scala/vlthr/tee/expr.scala
+++ b/app/src/main/scala/vlthr/tee/expr.scala
@@ -145,6 +145,7 @@ final case class FilterExpr(
     try {
       (exprVal zip argsVal) flatMap {
         case (e, as) =>
+          println(s"Trying to call filter ${filter} with ($e, $as)")
           imbueFragments(filter.apply(e, as))
       }
     } catch {

--- a/app/src/main/scala/vlthr/tee/expr.scala
+++ b/app/src/main/scala/vlthr/tee/expr.scala
@@ -136,10 +136,7 @@ final case class FilterExpr(expr: Expr,
                             filter: Filter,
                             args: List[Expr],
                             kwargs: Map[String, Expr])(
-    implicit val pctx: ParseContext,
-    hkArgs: HKernelAux[filter.Args],
-    ftArgs: FromTraversable[filter.Args],
-    ftOpt: FromTraversable[filter.OptArgs])
+    implicit val pctx: ParseContext)
     extends Expr {
   override def eval()(implicit ctx: Context) = {
     val exprVal = expr.eval()

--- a/app/src/main/scala/vlthr/tee/expr.scala
+++ b/app/src/main/scala/vlthr/tee/expr.scala
@@ -145,7 +145,6 @@ final case class FilterExpr(
     try {
       (exprVal zip argsVal) flatMap {
         case (e, as) =>
-          println(s"Trying to call filter ${filter} with ($e, $as)")
           imbueFragments(filter.apply(e, as))
       }
     } catch {

--- a/app/src/main/scala/vlthr/tee/filters.scala
+++ b/app/src/main/scala/vlthr/tee/filters.scala
@@ -451,3 +451,21 @@ case class Slice()
     }
   }
 }
+
+import shapeless._
+import shapeless.syntax.std.traversable._
+abstract trait NFilter() {
+  type Args
+  def filter(args: Args): Value
+  def checkArgs(args: List[Value]) = {
+    val l = List(args(0), args(1)).toHList
+    filter(l)
+  }
+}
+
+case class F1() extends NFilter {
+  type Args = IntValue :: StringValue :: HNil
+  def filter(args: Args) = {
+    println(args)
+  }
+}

--- a/app/src/main/scala/vlthr/tee/filters.scala
+++ b/app/src/main/scala/vlthr/tee/filters.scala
@@ -10,10 +10,6 @@ import vlthr.tee.typetraits.TypeTraits._
 import scala.collection.mutable.{Map => MMap, Set => MSet}
 import com.fasterxml.jackson.databind.ObjectMapper
 import shapeless._
-import shapeless.ops.hlist.HKernelAux
-import shapeless.ops.traversable._
-import shapeless.labelled._
-import shapeless.syntax.typeable._
 
 object Filter {
   def byName(s: String): Option[Filter] = registry.get(s)
@@ -39,14 +35,10 @@ object Filter {
 }
 
 case class UnknownFilter(name: String) extends Filter {
-  def filter(input: Value, args: List[Value], kwargs: Map[String, Value])(
-      implicit ctx: Context) =
+  type Args = HNil
+  type OptArgs = HNil
+  def filter(args: Args, optArgs: OptArgs)(implicit ctx: Context) =
     failFragment(UnknownFilterName(name))
-  def checkKwArgs(kwargs: Map[String, Value])(
-      implicit ctx: Context): List[ErrorFragment] = Nil
-  def checkInput(v: Value)(implicit ctx: Context) =
-    UnknownFilterName(name) :: Nil
-  def checkArgs(v: List[Value])(implicit ctx: Context) = Nil
 }
 
 // case class Split()
@@ -461,52 +453,6 @@ case class UnknownFilter(name: String) extends Filter {
 // import shapeless._
 // import shapeless.syntax.std.traversable._
 // object ValueTypeables {
-//   implicit val intTypeable: Typeable[IntValue] =
-//     new Typeable[IntValue] {
-//       def cast(t: Any): Option[IntValue] = t match {
-//         case c: IntValue => Some(c)
-//         case _ => None
-//       }
-
-//       def describe: String = s"IntValue"
-//     }
-
-//   implicit val stringTypeable: Typeable[StringValue] =
-//     new Typeable[StringValue] {
-//       def cast(t: Any): Option[StringValue] = t match {
-//         case v: StringValue => Some(v)
-//         case _ => None
-//       }
-
-//       def describe: String = s"StringValue"
-//     }
-//   implicit val mapTypeable: Typeable[MapValue] =
-//     new Typeable[MapValue] {
-//       def cast(t: Any): Option[MapValue] = t match {
-//         case v: MapValue => Some(v)
-//         case _ => None
-//       }
-
-//       def describe: String = s"MapValue"
-//     }
-//   implicit val listTypeable: Typeable[ListValue] =
-//     new Typeable[ListValue] {
-//       def cast(t: Any): Option[ListValue] = t match {
-//         case v: ListValue => Some(v)
-//         case _ => None
-//       }
-
-//       def describe: String = s"ListValue"
-//     }
-//   implicit val boolTypeable: Typeable[BooleanValue] =
-//     new Typeable[BooleanValue] {
-//       def cast(t: Any): Option[BooleanValue] = t match {
-//         case v: BooleanValue => Some(v)
-//         case _ => None
-//       }
-
-//       def describe: String = s"BooleanValue"
-//     }
 // }
 
 // object FromMap {
@@ -524,18 +470,5 @@ case class UnknownFilter(name: String) extends Filter {
 
 //   trait FromMap[L <: HList] {
 //     def apply(map: Map[String, Value]): L
-//   }
-// }
-
-// abstract trait NFilter() {
-//   type Args <: HList
-//   type OptArgs <: HList
-//   def filter(args: Args, optArgs: OptArgs): Validated[Value]
-//   def intLen[T <: HList](implicit ker: HKernelAux[T]): Int = ker().length
-//   def apply[L <: HList](allArgs: List[Value])(implicit ctx: Context, ftArgs: FromTraversable[Args], hkArgs: HKernelAux[Args], ftOpt: FromTraversable[OptArgs]): Validated[Value] = {
-//     val (args, optArgs) = allArgs.splitAt(intLen[Args])
-//     val a = ftArgs(args).get
-//     val o = ftOpt(optArgs).get
-//     filter(a, o)
 //   }
 // }

--- a/app/src/main/scala/vlthr/tee/filters.scala
+++ b/app/src/main/scala/vlthr/tee/filters.scala
@@ -4,7 +4,8 @@ import scala.util.control.NonFatal
 import vlthr.tee.parser.Liquid
 import vlthr.tee.core._
 import vlthr.tee.util._
-import vlthr.tee.core.Error._
+import vlthr.tee.core.Errors._
+import validation.Result
 import vlthr.tee.typetraits.TypeTraits._
 import scala.collection.mutable.{Map => MMap, Set => MSet}
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -13,35 +14,34 @@ import shapeless.ops.hlist.HKernelAux
 import shapeless.ops.traversable._
 import shapeless.labelled._
 import shapeless.syntax.typeable._
-import ValueTypeables._
 
 object Filter {
   def byName(s: String): Option[Filter] = registry.get(s)
   val registry: MMap[String, Filter] = MMap(
-    "split" -> Split(),
-    "date" -> Date(),
-    "slice" -> Slice(),
-    "join" -> Join(),
-    "size" -> Size(),
-    "json" -> Json(),
-    "first" -> First(),
-    "last" -> Last(),
-    "prepend" -> Prepend(),
-    "append" -> Append(),
-    "capitalize" -> Capitalize(),
-    "downcase" -> Downcase(),
-    "upcase" -> Upcase(),
-    "escape" -> Escape(),
-    "remove" -> Remove(),
-    "replace" -> Replace(),
-    "reverse" -> Reverse()
+    // "split" -> Split(),
+    // "date" -> Date(),
+    // "slice" -> Slice(),
+    // "join" -> Join(),
+    // "size" -> Size(),
+    // "json" -> Json(),
+    // "first" -> First(),
+    // "last" -> Last(),
+    // "prepend" -> Prepend(),
+    // "append" -> Append(),
+    // "capitalize" -> Capitalize(),
+    // "downcase" -> Downcase(),
+    // "upcase" -> Upcase(),
+    // "escape" -> Escape(),
+    // "remove" -> Remove(),
+    // "replace" -> Replace(),
+    // "reverse" -> Reverse()
   )
 }
 
 case class UnknownFilter(name: String) extends Filter {
   def filter(input: Value, args: List[Value], kwargs: Map[String, Value])(
       implicit ctx: Context) =
-    fail(UnknownFilterName(name))
+    failFragment(UnknownFilterName(name))
   def checkKwArgs(kwargs: Map[String, Value])(
       implicit ctx: Context): List[ErrorFragment] = Nil
   def checkInput(v: Value)(implicit ctx: Context) =
@@ -49,495 +49,493 @@ case class UnknownFilter(name: String) extends Filter {
   def checkArgs(v: List[Value])(implicit ctx: Context) = Nil
 }
 
-case class Split()
-    extends Filter
-    with InputType(ValueType.String)
-    with FixedArgs(ValueType.String)
-    with NoOptArgs
-    with NoKwArgs {
-  def name = "split"
-  override def filter(input: Value,
-                      args: List[Value],
-                      kwargs: Map[String, Value])(implicit ctx: Context) = {
-    val pattern = args(0).asInstanceOf[StringValue]
-    input match {
-      case StringValue(v) => Try(Value.create(v.split(pattern.v).toList))
-      case v => fail(UnexpectedValueType(v))
-    }
-  }
-}
+// case class Split()
+//     extends Filter
+//     with InputType(ValueType.String)
+//     with FixedArgs(ValueType.String)
+//     with NoOptArgs
+//     with NoKwArgs {
+//   def name = "split"
+//   override def filter(input: Value,
+//                       args: List[Value],
+//                       kwargs: Map[String, Value])(implicit ctx: Context) = {
+//     val pattern = args(0).asInstanceOf[StringValue]
+//     input match {
+//       case StringValue(v) => Try(Value.create(v.split(pattern.v).toList))
+//       case v => failFragment(UnexpectedValueType(v))
+//     }
+//   }
+// }
 
-case class Json()
-    extends Filter
-    with InputType(ValueType.List)
-    with NoArgs
-    with NoKwArgs {
-  def name = "json"
-  override def filter(input: Value,
-                      args: List[Value],
-                      kwargs: Map[String, Value])(implicit ctx: Context) =
-    Success(
-      StringValue(
-        new ObjectMapper()
-          .writeValueAsString(Util.asJava(input.asInstanceOf[ListValue]))))
-}
+// case class Json()
+//     extends Filter
+//     with InputType(ValueType.List)
+//     with NoArgs
+//     with NoKwArgs {
+//   def name = "json"
+//   override def filter(input: Value,
+//                       args: List[Value],
+//                       kwargs: Map[String, Value])(implicit ctx: Context) =
+//     Result.valid(
+//       StringValue(
+//         new ObjectMapper()
+//           .writeValueAsString(Util.asJava(input.asInstanceOf[ListValue]))))
+// }
 
-case class Size()
-    extends Filter
-    with InputType(ValueType.List | ValueType.String)
-    with NoArgs
-    with NoKwArgs {
-  def name = "size"
-  override def filter(input: Value,
-                      args: List[Value],
-                      kwargs: Map[String, Value])(implicit ctx: Context) =
-    input match {
-      case StringValue(v) => Try(IntValue(v.size))
-      case ListValue(v) => Try(IntValue(v.size))
-      case v => fail(UnexpectedValueType(v))
-    }
-}
+// case class Size()
+//     extends Filter
+//     with InputType(ValueType.List | ValueType.String)
+//     with NoArgs
+//     with NoKwArgs {
+//   def name = "size"
+//   override def filter(input: Value,
+//                       args: List[Value],
+//                       kwargs: Map[String, Value])(implicit ctx: Context) =
+//     input match {
+//       case StringValue(v) => Try(IntValue(v.size))
+//       case ListValue(v) => Try(IntValue(v.size))
+//       case v => failFragment(UnexpectedValueType(v))
+//     }
+// }
 
-case class First()
-    extends Filter
-    with InputType(ValueType.List | ValueType.String)
-    with NoArgs
-    with NoKwArgs {
-  def name = "first"
-  override def filter(input: Value,
-                      args: List[Value],
-                      kwargs: Map[String, Value])(implicit ctx: Context) =
-    input match {
-      case StringValue(v) => Try(StringValue("" + v.head))
-      case ListValue(v) => Try(v.head)
-      case v => fail(UnexpectedValueType(v))
-    }
-}
+// case class First()
+//     extends Filter
+//     with InputType(ValueType.List | ValueType.String)
+//     with NoArgs
+//     with NoKwArgs {
+//   def name = "first"
+//   override def filter(input: Value,
+//                       args: List[Value],
+//                       kwargs: Map[String, Value])(implicit ctx: Context) =
+//     input match {
+//       case StringValue(v) => Try(StringValue("" + v.head))
+//       case ListValue(v) => Try(v.head)
+//       case v => failFragment(UnexpectedValueType(v))
+//     }
+// }
 
-case class Last()
-    extends Filter
-    with InputType(ValueType.List | ValueType.String)
-    with NoArgs
-    with NoKwArgs {
-  def name = "last"
-  override def filter(input: Value,
-                      args: List[Value],
-                      kwargs: Map[String, Value])(implicit ctx: Context) =
-    input match {
-      case StringValue(v) => Try(StringValue("" + v.last))
-      case ListValue(v) => Try(v.last)
-      case v => fail(UnexpectedValueType(v))
-    }
-}
+// case class Last()
+//     extends Filter
+//     with InputType(ValueType.List | ValueType.String)
+//     with NoArgs
+//     with NoKwArgs {
+//   def name = "last"
+//   override def filter(input: Value,
+//                       args: List[Value],
+//                       kwargs: Map[String, Value])(implicit ctx: Context) =
+//     input match {
+//       case StringValue(v) => Try(StringValue("" + v.last))
+//       case ListValue(v) => Try(v.last)
+//       case v => failFragment(UnexpectedValueType(v))
+//     }
+// }
 
-case class Reverse()
-    extends Filter
-    with InputType(ValueType.List | ValueType.String)
-    with NoArgs
-    with NoKwArgs {
-  def name = "reverse"
-  override def filter(input: Value,
-                      args: List[Value],
-                      kwargs: Map[String, Value])(implicit ctx: Context) =
-    input match {
-      case StringValue(v) => Try(StringValue(v.reverse))
-      case ListValue(v) => Try(ListValue(v.reverse))
-      case v => fail(UnexpectedValueType(v))
-    }
-}
+// case class Reverse()
+//     extends Filter
+//     with InputType(ValueType.List | ValueType.String)
+//     with NoArgs
+//     with NoKwArgs {
+//   def name = "reverse"
+//   override def filter(input: Value,
+//                       args: List[Value],
+//                       kwargs: Map[String, Value])(implicit ctx: Context) =
+//     input match {
+//       case StringValue(v) => Try(StringValue(v.reverse))
+//       case ListValue(v) => Try(ListValue(v.reverse))
+//       case v => failFragment(UnexpectedValueType(v))
+//     }
+// }
 
-case class Join()
-    extends Filter
-    with InputType(ValueType.List)
-    with FixedArgs(ValueType.String)
-    with NoOptArgs
-    with NoKwArgs {
-  def name = "join"
-  override def filter(input: Value,
-                      args: List[Value],
-                      kwargs: Map[String, Value])(implicit ctx: Context) = {
-    val delim = args(0).asInstanceOf[StringValue]
-    input match {
-      case ListValue(v) =>
-        Try(StringValue(v.map(_.render().get).mkString(delim.v)))
-      case v => fail(UnexpectedValueType(v))
-    }
-  }
-}
+// case class Join()
+//     extends Filter
+//     with InputType(ValueType.List)
+//     with FixedArgs(ValueType.String)
+//     with NoOptArgs
+//     with NoKwArgs {
+//   def name = "join"
+//   override def filter(input: Value,
+//                       args: List[Value],
+//                       kwargs: Map[String, Value])(implicit ctx: Context) = {
+//     val delim = args(0).asInstanceOf[StringValue]
+//     input match {
+//       case ListValue(v) =>
+//         Try(StringValue(v.map(_.render().get).mkString(delim.v)))
+//       case v => failFragment(UnexpectedValueType(v))
+//     }
+//   }
+// }
 
-case class Capitalize()
-    extends Filter
-    with InputType(ValueType.String)
-    with NoArgs
-    with NoKwArgs {
-  def name = "capitalize"
-  override def filter(input: Value,
-                      args: List[Value],
-                      kwargs: Map[String, Value])(implicit ctx: Context) = {
-    input match {
-      case StringValue(v) =>
-        Try(StringValue(Character.toUpperCase(v(0)) + v.substring(1)))
-      case v => fail(UnexpectedValueType(v))
-    }
-  }
-}
+// case class Capitalize()
+//     extends Filter
+//     with InputType(ValueType.String)
+//     with NoArgs
+//     with NoKwArgs {
+//   def name = "capitalize"
+//   override def filter(input: Value,
+//                       args: List[Value],
+//                       kwargs: Map[String, Value])(implicit ctx: Context) = {
+//     input match {
+//       case StringValue(v) =>
+//         Try(StringValue(Character.toUpperCase(v(0)) + v.substring(1)))
+//       case v => failFragment(UnexpectedValueType(v))
+//     }
+//   }
+// }
 
-case class Downcase()
-    extends Filter
-    with InputType(ValueType.String)
-    with NoArgs
-    with NoKwArgs {
-  def name = "downcase"
-  override def filter(input: Value,
-                      args: List[Value],
-                      kwargs: Map[String, Value])(implicit ctx: Context) = {
-    input match {
-      case StringValue(v) =>
-        Try(StringValue(v.map(c => Character.toLowerCase(c)).mkString))
-      case v => fail(UnexpectedValueType(v))
-    }
-  }
-}
+// case class Downcase()
+//     extends Filter
+//     with InputType(ValueType.String)
+//     with NoArgs
+//     with NoKwArgs {
+//   def name = "downcase"
+//   override def filter(input: Value,
+//                       args: List[Value],
+//                       kwargs: Map[String, Value])(implicit ctx: Context) = {
+//     input match {
+//       case StringValue(v) =>
+//         Try(StringValue(v.map(c => Character.toLowerCase(c)).mkString))
+//       case v => failFragment(UnexpectedValueType(v))
+//     }
+//   }
+// }
 
-case class Upcase()
-    extends Filter
-    with InputType(ValueType.String)
-    with NoArgs
-    with NoKwArgs {
-  def name = "upcase"
-  override def filter(input: Value,
-                      args: List[Value],
-                      kwargs: Map[String, Value])(implicit ctx: Context) = {
-    input match {
-      case StringValue(v) =>
-        Try(StringValue(v.map(c => Character.toUpperCase(c)).mkString))
-      case v => fail(UnexpectedValueType(v))
-    }
-  }
-}
+// case class Upcase()
+//     extends Filter
+//     with InputType(ValueType.String)
+//     with NoArgs
+//     with NoKwArgs {
+//   def name = "upcase"
+//   override def filter(input: Value,
+//                       args: List[Value],
+//                       kwargs: Map[String, Value])(implicit ctx: Context) = {
+//     input match {
+//       case StringValue(v) =>
+//         Try(StringValue(v.map(c => Character.toUpperCase(c)).mkString))
+//       case v => failFragment(UnexpectedValueType(v))
+//     }
+//   }
+// }
 
-case class Append()
-    extends Filter
-    with InputType(ValueType.String)
-    with FixedArgs(ValueType.String)
-    with NoOptArgs
-    with NoKwArgs {
-  def name = "append"
-  override def filter(input: Value,
-                      args: List[Value],
-                      kwargs: Map[String, Value])(implicit ctx: Context) = {
-    val end = args(0).asInstanceOf[StringValue]
-    input match {
-      case StringValue(v) => Try(StringValue(v + end.v))
-      case v => fail(UnexpectedValueType(v))
-    }
-  }
-}
+// case class Append()
+//     extends Filter
+//     with InputType(ValueType.String)
+//     with FixedArgs(ValueType.String)
+//     with NoOptArgs
+//     with NoKwArgs {
+//   def name = "append"
+//   override def filter(input: Value,
+//                       args: List[Value],
+//                       kwargs: Map[String, Value])(implicit ctx: Context) = {
+//     val end = args(0).asInstanceOf[StringValue]
+//     input match {
+//       case StringValue(v) => Try(StringValue(v + end.v))
+//       case v => failFragment(UnexpectedValueType(v))
+//     }
+//   }
+// }
 
-case class Prepend()
-    extends Filter
-    with InputType(ValueType.String)
-    with FixedArgs(ValueType.String)
-    with NoOptArgs
-    with NoKwArgs {
-  def name = "prepend"
-  override def filter(input: Value,
-                      args: List[Value],
-                      kwargs: Map[String, Value])(implicit ctx: Context) = {
-    val start = args(0).asInstanceOf[StringValue]
-    input match {
-      case StringValue(v) => Try(StringValue(start.v + v))
-      case v => fail(UnexpectedValueType(v))
-    }
-  }
-}
+// case class Prepend()
+//     extends Filter
+//     with InputType(ValueType.String)
+//     with FixedArgs(ValueType.String)
+//     with NoOptArgs
+//     with NoKwArgs {
+//   def name = "prepend"
+//   override def filter(input: Value,
+//                       args: List[Value],
+//                       kwargs: Map[String, Value])(implicit ctx: Context) = {
+//     val start = args(0).asInstanceOf[StringValue]
+//     input match {
+//       case StringValue(v) => Try(StringValue(start.v + v))
+//       case v => failFragment(UnexpectedValueType(v))
+//     }
+//   }
+// }
 
-case class Escape()
-    extends Filter
-    with InputType(ValueType.String)
-    with NoArgs
-    with NoKwArgs {
-  def name = "escape"
-  override def filter(input: Value,
-                      args: List[Value],
-                      kwargs: Map[String, Value])(implicit ctx: Context) = {
-    input match {
-      case StringValue(v) =>
-        Try(
-          StringValue(
-            v.replace("<", "&lt;")
-              .replace(">", "&gt;")
-              .replace("\"", "&quot;")
-              .replace("&", "&amp;")))
-      case v => fail(UnexpectedValueType(v))
-    }
-  }
-}
+// case class Escape()
+//     extends Filter
+//     with InputType(ValueType.String)
+//     with NoArgs
+//     with NoKwArgs {
+//   def name = "escape"
+//   override def filter(input: Value,
+//                       args: List[Value],
+//                       kwargs: Map[String, Value])(implicit ctx: Context) = {
+//     input match {
+//       case StringValue(v) =>
+//         Try(
+//           StringValue(
+//             v.replace("<", "&lt;")
+//               .replace(">", "&gt;")
+//               .replace("\"", "&quot;")
+//               .replace("&", "&amp;")))
+//       case v => failFragment(UnexpectedValueType(v))
+//     }
+//   }
+// }
 
-case class Remove()
-    extends Filter
-    with InputType(ValueType.String)
-    with FixedArgs(ValueType.String)
-    with NoOptArgs
-    with NoKwArgs {
-  def name = "remove"
-  override def filter(input: Value,
-                      args: List[Value],
-                      kwargs: Map[String, Value])(implicit ctx: Context) = {
-    val pattern = args(0).asInstanceOf[StringValue]
-    input match {
-      case StringValue(v) => Try(StringValue(v.replace(pattern.v, "")))
-      case v => fail(UnexpectedValueType(v))
-    }
-  }
-}
+// case class Remove()
+//     extends Filter
+//     with InputType(ValueType.String)
+//     with FixedArgs(ValueType.String)
+//     with NoOptArgs
+//     with NoKwArgs {
+//   def name = "remove"
+//   override def filter(input: Value,
+//                       args: List[Value],
+//                       kwargs: Map[String, Value])(implicit ctx: Context) = {
+//     val pattern = args(0).asInstanceOf[StringValue]
+//     input match {
+//       case StringValue(v) => Try(StringValue(v.replace(pattern.v, "")))
+//       case v => failFragment(UnexpectedValueType(v))
+//     }
+//   }
+// }
 
-case class Replace()
-    extends Filter
-    with InputType(ValueType.String)
-    with FixedArgs(ValueType.String, ValueType.String)
-    with NoOptArgs
-    with NoKwArgs {
-  def name = "replace"
-  override def filter(input: Value,
-                      args: List[Value],
-                      kwargs: Map[String, Value])(implicit ctx: Context) = {
-    val pattern = args(0).asInstanceOf[StringValue]
-    val replacement = args(1).asInstanceOf[StringValue]
-    input match {
-      case StringValue(v) =>
-        Try(StringValue(v.replace(pattern.v, replacement.v)))
-      case v => fail(UnexpectedValueType(v))
-    }
-  }
-}
+// case class Replace()
+//     extends Filter
+//     with InputType(ValueType.String)
+//     with FixedArgs(ValueType.String, ValueType.String)
+//     with NoOptArgs
+//     with NoKwArgs {
+//   def name = "replace"
+//   override def filter(input: Value,
+//                       args: List[Value],
+//                       kwargs: Map[String, Value])(implicit ctx: Context) = {
+//     val pattern = args(0).asInstanceOf[StringValue]
+//     val replacement = args(1).asInstanceOf[StringValue]
+//     input match {
+//       case StringValue(v) =>
+//         Try(StringValue(v.replace(pattern.v, replacement.v)))
+//       case v => failFragment(UnexpectedValueType(v))
+//     }
+//   }
+// }
 
-case class Date()
-    extends Filter
-    with InputType(ValueType.String | ValueType.Integer)
-    with FixedArgs(ValueType.String)
-    with NoOptArgs
-    with NoKwArgs {
-  import java.text.SimpleDateFormat
-  import java.util.Locale
+// case class Date()
+//     extends Filter
+//     with InputType(ValueType.String | ValueType.Integer)
+//     with FixedArgs(ValueType.String)
+//     with NoOptArgs
+//     with NoKwArgs {
+//   import java.text.SimpleDateFormat
+//   import java.util.Locale
 
-  def name = "date"
-  val locale = Locale.ENGLISH
-  val datePatterns: List[String] =
-    List("yyyy-MM-dd HH:mm:ss", "EEE MMM dd hh:mm:ss yyyy")
+//   def name = "date"
+//   val locale = Locale.ENGLISH
+//   val datePatterns: List[String] =
+//     List("yyyy-MM-dd HH:mm:ss", "EEE MMM dd hh:mm:ss yyyy")
 
-  def liquidToJavaFormat =
-    Map(
-      // %% - Literal ``%'' character
-      '%' -> new SimpleDateFormat("%", locale),
-      // %a - The abbreviated weekday name (``Sun'')
-      'a' -> new SimpleDateFormat("EEE", locale),
-      // %A - The  full  weekday  name (``Sunday'')
-      'A' -> new SimpleDateFormat("EEEE", locale),
-      // %b - The abbreviated month name (``Jan'')
-      'b' -> new SimpleDateFormat("MMM", locale),
-      'h' -> new SimpleDateFormat("MMM", locale),
-      // %B - The  full  month  name (``January'')
-      'B' -> new SimpleDateFormat("MMMM", locale),
-      // %c - The preferred local date and time representation
-      'c' -> new SimpleDateFormat("EEE MMM dd HH:mm:ss yyyy", locale),
-      // %d - Day of the month (01..31)
-      'd' -> new SimpleDateFormat("dd", locale),
-      // %H - Hour of the day, 24-hour clock (00..23)
-      'H' -> new SimpleDateFormat("HH", locale),
-      // %I - Hour of the day, 12-hour clock (01..12)
-      'I' -> new SimpleDateFormat("hh", locale),
-      // %j - Day of the year (001..366)
-      'j' -> new SimpleDateFormat("DDD", locale),
-      // %m - Month of the year (01..12)
-      'm' -> new SimpleDateFormat("MM", locale),
-      // %M - Minute of the hour (00..59)
-      'M' -> new SimpleDateFormat("mm", locale),
-      // %p - Meridian indicator (``AM''  or  ``PM'')
-      'p' -> new SimpleDateFormat("a", locale),
-      // %S - Second of the minute (00..60)
-      'S' -> new SimpleDateFormat("ss", locale),
-      // %U - Week  number  of the current year,
-      //      starting with the first Sunday as the first
-      //      day of the first week (00..53)
-      'U' -> new SimpleDateFormat("ww", locale),
-      // %W - Week  number  of the current year,
-      //      starting with the first Monday as the first
-      //      day of the first week (00..53)
-      'W' -> new SimpleDateFormat("ww", locale),
-      // %w - Day of the week (Sunday is 0, 0..6)
-      'w' -> new SimpleDateFormat("F", locale),
-      // %x - Preferred representation for the date alone, no time
-      'x' -> new SimpleDateFormat("MM/dd/yy", locale),
-      // %X - Preferred representation for the time alone, no date
-      'X' -> new SimpleDateFormat("HH:mm:ss", locale),
-      // %y - Year without a century (00..99)
-      'y' -> new SimpleDateFormat("yy", locale),
-      // %Y - Year with century
-      'Y' -> new SimpleDateFormat("yyyy", locale),
-      // %Z - Time zone name
-      'Z' -> new SimpleDateFormat("z", locale)
-    )
+//   def liquidToJavaFormat =
+//     Map(
+//       // %% - Literal ``%'' character
+//       '%' -> new SimpleDateFormat("%", locale),
+//       // %a - The abbreviated weekday name (``Sun'')
+//       'a' -> new SimpleDateFormat("EEE", locale),
+//       // %A - The  full  weekday  name (``Sunday'')
+//       'A' -> new SimpleDateFormat("EEEE", locale),
+//       // %b - The abbreviated month name (``Jan'')
+//       'b' -> new SimpleDateFormat("MMM", locale),
+//       'h' -> new SimpleDateFormat("MMM", locale),
+//       // %B - The  full  month  name (``January'')
+//       'B' -> new SimpleDateFormat("MMMM", locale),
+//       // %c - The preferred local date and time representation
+//       'c' -> new SimpleDateFormat("EEE MMM dd HH:mm:ss yyyy", locale),
+//       // %d - Day of the month (01..31)
+//       'd' -> new SimpleDateFormat("dd", locale),
+//       // %H - Hour of the day, 24-hour clock (00..23)
+//       'H' -> new SimpleDateFormat("HH", locale),
+//       // %I - Hour of the day, 12-hour clock (01..12)
+//       'I' -> new SimpleDateFormat("hh", locale),
+//       // %j - Day of the year (001..366)
+//       'j' -> new SimpleDateFormat("DDD", locale),
+//       // %m - Month of the year (01..12)
+//       'm' -> new SimpleDateFormat("MM", locale),
+//       // %M - Minute of the hour (00..59)
+//       'M' -> new SimpleDateFormat("mm", locale),
+//       // %p - Meridian indicator (``AM''  or  ``PM'')
+//       'p' -> new SimpleDateFormat("a", locale),
+//       // %S - Second of the minute (00..60)
+//       'S' -> new SimpleDateFormat("ss", locale),
+//       // %U - Week  number  of the current year,
+//       //      starting with the first Sunday as the first
+//       //      day of the first week (00..53)
+//       'U' -> new SimpleDateFormat("ww", locale),
+//       // %W - Week  number  of the current year,
+//       //      starting with the first Monday as the first
+//       //      day of the first week (00..53)
+//       'W' -> new SimpleDateFormat("ww", locale),
+//       // %w - Day of the week (Sunday is 0, 0..6)
+//       'w' -> new SimpleDateFormat("F", locale),
+//       // %x - Preferred representation for the date alone, no time
+//       'x' -> new SimpleDateFormat("MM/dd/yy", locale),
+//       // %X - Preferred representation for the time alone, no date
+//       'X' -> new SimpleDateFormat("HH:mm:ss", locale),
+//       // %y - Year without a century (00..99)
+//       'y' -> new SimpleDateFormat("yy", locale),
+//       // %Y - Year with century
+//       'Y' -> new SimpleDateFormat("yyyy", locale),
+//       // %Z - Time zone name
+//       'Z' -> new SimpleDateFormat("z", locale)
+//     )
 
-  def toSeconds(date: String): Option[Long] = {
-    datePatterns
-      .map(pattern =>
-        Try(new SimpleDateFormat(pattern, locale).parse(date).getTime / 1000L))
-      .map(_.toOption)
-      .flatten
-      .headOption
-  }
+//   def toSeconds(date: String): Option[Long] = {
+//     datePatterns
+//       .map(pattern =>
+//         Try(new SimpleDateFormat(pattern, locale).parse(date).getTime / 1000L))
+//       .map(_.toOption)
+//       .flatten
+//       .headOption
+//   }
 
-  case class InvalidDate(filter: Filter, date: String) extends ExtensionError {
-    def description = s"`$date` is not a valid date."
-  }
-  override def filter(
-      input: Value,
-      args: List[Value],
-      kwargs: Map[String, Value])(implicit ctx: Context): Try[Value] = {
-    val seconds: Long = input match {
-      case StringValue(v) if v == "now" => System.currentTimeMillis / 1000L
-      case StringValue(v) =>
-        toSeconds(v).getOrElse(return fail(InvalidDate(this, v)))
-      case IntValue(v) => v
-      case v => return fail(UnexpectedValueType(v)); 1L
-    }
-    val date = new java.util.Date(seconds * 1000L)
+//   case class InvalidDate(filter: Filter, date: String) extends ExtensionError {
+//     def description = s"`$date` is not a valid date."
+//   }
+//   override def filter(
+//       input: Value,
+//       args: List[Value],
+//       kwargs: Map[String, Value])(implicit ctx: Context): Validated[Value] = {
+//     val seconds: Long = input match {
+//       case StringValue(v) if v == "now" => System.currentTimeMillis / 1000L
+//       case StringValue(v) =>
+//         toSeconds(v).getOrElse(return failFragment(InvalidDate(this, v)))
+//       case IntValue(v) => v
+//       case v => return failFragment(UnexpectedValueType(v)); 1L
+//     }
+//     val date = new java.util.Date(seconds * 1000L)
 
-    val format = args(0).asInstanceOf[StringValue].v
-    val calendar = java.util.Calendar.getInstance()
-    calendar.setTime(date)
+//     val format = args(0).asInstanceOf[StringValue].v
+//     val calendar = java.util.Calendar.getInstance()
+//     calendar.setTime(date)
 
-    val builder = new StringBuilder();
+//     val builder = new StringBuilder();
 
-    var i = 0
-    while (i < format.length) {
-      val ch = format.charAt(i);
-      if (ch == '%') {
-        i += 1
+//     var i = 0
+//     while (i < format.length) {
+//       val ch = format.charAt(i);
+//       if (ch == '%') {
+//         i += 1
 
-        if (i == format.length()) {
-          builder.append("%")
-        } else {
-          val next = format.charAt(i);
+//         if (i == format.length()) {
+//           builder.append("%")
+//         } else {
+//           val next = format.charAt(i);
 
-          val javaFormat = liquidToJavaFormat.get(next);
+//           val javaFormat = liquidToJavaFormat.get(next);
 
-          javaFormat match {
-            case Some(f) => builder.append(f.format(date))
-            case _ => builder.append("%").append(next);
-          }
-        }
-      } else {
-        builder.append(ch);
-      }
-      i += 1
-    }
-    Success(StringValue(builder.toString))
-  }
-}
+//           javaFormat match {
+//             case Some(f) => builder.append(f.format(date))
+//             case _ => builder.append("%").append(next);
+//           }
+//         }
+//       } else {
+//         builder.append(ch);
+//       }
+//       i += 1
+//     }
+//     Result.valid(StringValue(builder.toString))
+//   }
+// }
 
-case class Slice()
-    extends Filter
-    with InputType(ValueType.String)
-    with FixedArgs(ValueType.Integer)
-    with NoOptArgs
-    with NoKwArgs {
-  def name = "slice"
-  override def filter(input: Value,
-                      args: List[Value],
-                      kwargs: Map[String, Value])(
-      // TODO: Support negative indexes
-      implicit ctx: Context): Try[Value] = {
-    val start = args(0).asInstanceOf[IntValue].v
-    val stop = args.lift(1).map(_.asInstanceOf[IntValue].v).getOrElse(start)
-    input match {
-      case StringValue(v) => Success(StringValue(v.substring(start, stop + 1)))
-      case v => fail(UnexpectedValueType(v))
-    }
-  }
-}
+// case class Slice()
+//     extends Filter
+//     with InputType(ValueType.String)
+//     with FixedArgs(ValueType.Integer)
+//     with NoOptArgs
+//     with NoKwArgs {
+//   def name = "slice"
+//   override def filter(input: Value,
+//                       args: List[Value],
+//                       kwargs: Map[String, Value])(
+//       // TODO: Support negative indexes
+//       implicit ctx: Context): Validated[Value] = {
+//     val start = args(0).asInstanceOf[IntValue].v
+//     val stop = args.lift(1).map(_.asInstanceOf[IntValue].v).getOrElse(start)
+//     input match {
+//       case StringValue(v) => Result.valid(StringValue(v.substring(start, stop + 1)))
+//       case v => failFragment(UnexpectedValueType(v))
+//     }
+//   }
+// }
 
-import shapeless._
-import shapeless.syntax.std.traversable._
+// import shapeless._
+// import shapeless.syntax.std.traversable._
+// object ValueTypeables {
+//   implicit val intTypeable: Typeable[IntValue] =
+//     new Typeable[IntValue] {
+//       def cast(t: Any): Option[IntValue] = t match {
+//         case c: IntValue => Some(c)
+//         case _ => None
+//       }
 
+//       def describe: String = s"IntValue"
+//     }
 
-object ValueTypeables {
-  implicit val intTypeable: Typeable[IntValue] =
-    new Typeable[IntValue] {
-      def cast(t: Any): Option[IntValue] = t match {
-        case c: IntValue => Some(c)
-        case _ => None
-      }
+//   implicit val stringTypeable: Typeable[StringValue] =
+//     new Typeable[StringValue] {
+//       def cast(t: Any): Option[StringValue] = t match {
+//         case v: StringValue => Some(v)
+//         case _ => None
+//       }
 
-      def describe: String = s"IntValue"
-    }
+//       def describe: String = s"StringValue"
+//     }
+//   implicit val mapTypeable: Typeable[MapValue] =
+//     new Typeable[MapValue] {
+//       def cast(t: Any): Option[MapValue] = t match {
+//         case v: MapValue => Some(v)
+//         case _ => None
+//       }
 
-  implicit val stringTypeable: Typeable[StringValue] =
-    new Typeable[StringValue] {
-      def cast(t: Any): Option[StringValue] = t match {
-        case v: StringValue => Some(v)
-        case _ => None
-      }
+//       def describe: String = s"MapValue"
+//     }
+//   implicit val listTypeable: Typeable[ListValue] =
+//     new Typeable[ListValue] {
+//       def cast(t: Any): Option[ListValue] = t match {
+//         case v: ListValue => Some(v)
+//         case _ => None
+//       }
 
-      def describe: String = s"StringValue"
-    }
-  implicit val mapTypeable: Typeable[MapValue] =
-    new Typeable[MapValue] {
-      def cast(t: Any): Option[MapValue] = t match {
-        case v: MapValue => Some(v)
-        case _ => None
-      }
+//       def describe: String = s"ListValue"
+//     }
+//   implicit val boolTypeable: Typeable[BooleanValue] =
+//     new Typeable[BooleanValue] {
+//       def cast(t: Any): Option[BooleanValue] = t match {
+//         case v: BooleanValue => Some(v)
+//         case _ => None
+//       }
 
-      def describe: String = s"MapValue"
-    }
-  implicit val listTypeable: Typeable[ListValue] =
-    new Typeable[ListValue] {
-      def cast(t: Any): Option[ListValue] = t match {
-        case v: ListValue => Some(v)
-        case _ => None
-      }
+//       def describe: String = s"BooleanValue"
+//     }
+// }
 
-      def describe: String = s"ListValue"
-    }
-  implicit val boolTypeable: Typeable[BooleanValue] =
-    new Typeable[BooleanValue] {
-      def cast(t: Any): Option[BooleanValue] = t match {
-        case v: BooleanValue => Some(v)
-        case _ => None
-      }
+// object FromMap {
+//   implicit def caseClassFromMap[T <: HList, C](map: Map[String, Value])(implicit kw: Lazy[FromMap[T]],
+//                                                                         gen: LabelledGeneric.Aux[C, T]): C = gen.from(kw.value(map))
 
-      def describe: String = s"BooleanValue"
-    }
-}
+//   implicit def kwsFromMap[K <: Symbol, H <: Value, T <: HList](implicit w: Witness.Aux[K],
+//                                                                tailToKw: Lazy[FromMap[T]]
+//   ): FromMap[FieldType[K, Option[H]] :: T] = (map) => {
+//       val key = w.value.name
+//       // TODO: Add error checking
+//       val value = map.get(key).flatMap(v => v.cast[H])
+//       field[K](value) :: tailToKw.value(map)
+//     }
 
-object FromMap {
-  implicit def caseClassFromMap[T <: HList, C](map: Map[String, Value])(implicit kw: Lazy[FromMap[T]],
-                                                                        gen: LabelledGeneric.Aux[C, T]): C = gen.from(kw.value(map))
+//   trait FromMap[L <: HList] {
+//     def apply(map: Map[String, Value]): L
+//   }
+// }
 
-  implicit def kwsFromMap[K <: Symbol, H <: Value, T <: HList](implicit w: Witness.Aux[K],
-                                                               tailToKw: Lazy[FromMap[T]]
-  ): FromMap[FieldType[K, Option[H]] :: T] = (map) => {
-      val key = w.value.name
-      // TODO: Add error checking
-      val value = map.get(key).flatMap(v => v.cast[H])
-      field[K](value) :: tailToKw.value(map)
-    }
-
-  trait FromMap[L <: HList] {
-    def apply(map: Map[String, Value]): L
-  }
-}
-
-abstract trait NFilter() {
-  type Args <: HList
-  type OptArgs <: HList
-  def filter(args: Args, optArgs: OptArgs): Try[Value]
-  def intLen[T <: HList](implicit ker: HKernelAux[T]): Int = ker().length
-  def apply[L <: HList](allArgs: List[Value])(implicit ctx: Context, ftArgs: FromTraversable[Args], hkArgs: HKernelAux[Args], ftOpt: FromTraversable[OptArgs]): Try[Value] = {
-    val (args, optArgs) = allArgs.splitAt(intLen[Args])
-    val a = ftArgs(args).get
-    val o = ftOpt(optArgs).get
-    filter(a, o)
-  }
-}
+// abstract trait NFilter() {
+//   type Args <: HList
+//   type OptArgs <: HList
+//   def filter(args: Args, optArgs: OptArgs): Validated[Value]
+//   def intLen[T <: HList](implicit ker: HKernelAux[T]): Int = ker().length
+//   def apply[L <: HList](allArgs: List[Value])(implicit ctx: Context, ftArgs: FromTraversable[Args], hkArgs: HKernelAux[Args], ftOpt: FromTraversable[OptArgs]): Validated[Value] = {
+//     val (args, optArgs) = allArgs.splitAt(intLen[Args])
+//     val a = ftArgs(args).get
+//     val o = ftOpt(optArgs).get
+//     filter(a, o)
+//   }
+// }

--- a/app/src/main/scala/vlthr/tee/filters.scala
+++ b/app/src/main/scala/vlthr/tee/filters.scala
@@ -43,7 +43,6 @@ package object filters {
         f(ctx, this, input, args, optArgs)
       def apply(input: Value, allArgs: List[Value])(
           implicit ctx: Context): ValidatedFragment[Value] = {
-        println(s"${this.name} => $input (${input.cast[Input]}), $allArgs")
         val (args, optArgs) = allArgs.splitAt(intLen[Args])
         val i = Result.fromOption(input.cast[Input], InvalidInput(this, input))
         val a = Result.fromOption(ftArgs(args), InvalidArgs(this, args))
@@ -68,14 +67,12 @@ package object filters {
         f(ctx, this, input, args, optArgs)
       def apply(input: Value, allArgs: List[Value])(
           implicit ctx: Context): ValidatedFragment[Value] = {
-        println(s"${this.name} => $input (${input.cast[Input]}), $allArgs")
         val (args, optArgs) = allArgs.splitAt(intLen[Args])
         val i = Result.fromOption(input.cast[Input], InvalidInput(this, input))
         val a = Result.fromOption(ftArgs(args), InvalidArgs(this, args))
         val maxNrOpts = intLen[OptArgs]
         val fixedOptArgs = optArgs.map(v => Some(v)) ++ List.fill(
           maxNrOpts - optArgs.size)(None)
-        println(fixedOptArgs)
         val o = ftOpt(fixedOptArgs).get
 
         (i zip a).flatMap { (i, a) =>

--- a/app/src/main/scala/vlthr/tee/filters.scala
+++ b/app/src/main/scala/vlthr/tee/filters.scala
@@ -454,11 +454,65 @@ case class Slice()
 
 import shapeless._
 import shapeless.syntax.std.traversable._
+
+
+object ValueTypeables {
+  implicit val intTypeable: Typeable[IntValue] =
+    new Typeable[IntValue] {
+      def cast(t: Any): Option[IntValue] = t match {
+        case c: IntValue => Some(c)
+        case _ => None
+      }
+
+      def describe: String = s"IntValue"
+    }
+
+  implicit val stringTypeable: Typeable[StringValue] =
+    new Typeable[StringValue] {
+      def cast(t: Any): Option[StringValue] = t match {
+        case v: StringValue => Some(v)
+        case _ => None
+      }
+
+      def describe: String = s"StringValue"
+    }
+  implicit val mapTypeable: Typeable[MapValue] =
+    new Typeable[MapValue] {
+      def cast(t: Any): Option[MapValue] = t match {
+        case v: MapValue => Some(v)
+        case _ => None
+      }
+
+      def describe: String = s"MapValue"
+    }
+  implicit val listTypeable: Typeable[ListValue] =
+    new Typeable[ListValue] {
+      def cast(t: Any): Option[ListValue] = t match {
+        case v: ListValue => Some(v)
+        case _ => None
+      }
+
+      def describe: String = s"ListValue"
+    }
+  implicit val boolTypeable: Typeable[BooleanValue] =
+    new Typeable[BooleanValue] {
+      def cast(t: Any): Option[BooleanValue] = t match {
+        case v: BooleanValue => Some(v)
+        case _ => None
+      }
+
+      def describe: String = s"BooleanValue"
+    }
+}
 abstract trait NFilter() {
-  type Args
+  import ValueTypeables._
+  import UnaryTCConstraint._
+  type Args <: HList
   def filter(args: Args): Value
   def checkArgs(args: List[Value]) = {
-    val l = List(args(0), args(1)).toHList
+    // val l = List(IntValue(1), StringValue("hi")).toHList[Args].get
+    val l = List(IntValue(1), StringValue("hi")).toHList[IntValue :: StringValue :: HNil].get
+    // val l = args.toHList[Args].get
     filter(l)
   }
 }

--- a/app/src/main/scala/vlthr/tee/filters.scala
+++ b/app/src/main/scala/vlthr/tee/filters.scala
@@ -504,10 +504,9 @@ object ValueTypeables {
       def describe: String = s"BooleanValue"
     }
 }
-abstract trait NFilter() {
+import UnaryTCConstraint._
+abstract trait NFilter[Args <: HList: *->*[Option]#λ]() {
   import ValueTypeables._
-  import UnaryTCConstraint._
-  type Args <: HList
   def filter(args: Args): Value
   def checkArgs(args: List[Value]) = {
     // val l = List(IntValue(1), StringValue("hi")).toHList[Args].get

--- a/app/src/main/scala/vlthr/tee/objects.scala
+++ b/app/src/main/scala/vlthr/tee/objects.scala
@@ -3,39 +3,39 @@ import scala.collection.mutable.{Map => MMap}
 import scala.util.{Try, Success, Failure}
 import vlthr.tee.parser.Liquid
 import scala.util.control.NonFatal
-import vlthr.tee.core.Error._
+import vlthr.tee.core.Errors._
 import java.nio.file.Paths
+import validation.Result
 
 final case class BlockNode(node: List[Obj])(implicit val pctx: ParseContext)
     extends Obj {
   def render()(implicit ctx: Context) = {
     implicit val newScope = Context.createChild(ctx)
-    val renders = node.map(_.render())
-    Error.all(renders: _*)(r => r).map(_.mkString)
+    val renders: Validated[List[String]] =
+      Result.sequence(node.map(_.render()))
+    renders.map(_.mkString)
   }
 }
 
 final case class OutputNode(expr: Expr)(implicit val pctx: ParseContext)
     extends Obj {
-  def render()(implicit ctx: Context) = Error.all(expr.render()) { e =>
-    e
-  }
+  def render()(implicit ctx: Context) = expr.render()
 }
 
 final case class TextNode(text: String)(implicit val pctx: ParseContext)
     extends Obj {
-  def render()(implicit ctx: Context): Try[String] = Success(text)
+  def render()(implicit ctx: Context): Validated[String] = Result.valid(text)
 }
 
 trait TagNode extends Obj with ASTNode {
-  def render()(implicit ctx: Context): Try[String] = ???
+  def render()(implicit ctx: Context): Validated[String] = ???
 }
 
 final case class CaptureTag(id: String, value: Obj)(
     implicit val pctx: ParseContext)
     extends TagNode {
-  override def render()(implicit ctx: Context): Try[String] = {
-    Error.all(value.render()) { v: String =>
+  override def render()(implicit ctx: Context): Validated[String] = {
+    value.render().map { v: String =>
       ctx.mappings.put(id, StringValue(v))
       ""
     }
@@ -45,8 +45,8 @@ final case class CaptureTag(id: String, value: Obj)(
 final case class AssignTag(id: String, value: Expr)(
     implicit val pctx: ParseContext)
     extends TagNode {
-  override def render()(implicit ctx: Context): Try[String] = {
-    Error.all(value.eval()) { v: Value =>
+  override def render()(implicit ctx: Context): Validated[String] = {
+    value.eval() map { v: Value =>
       ctx.mappings.put(id, v)
       ""
     }
@@ -55,8 +55,8 @@ final case class AssignTag(id: String, value: Expr)(
 
 final case class CommentTag()(implicit val pctx: ParseContext)
     extends TagNode {
-  override def render()(implicit ctx: Context): Try[String] =
-    Success("")
+  override def render()(implicit ctx: Context): Validated[String] =
+    Result.valid("")
 }
 
 final case class CycleTag()(implicit val pctx: ParseContext) extends TagNode
@@ -64,21 +64,21 @@ final case class CycleTag()(implicit val pctx: ParseContext) extends TagNode
 final case class ForTag(id: String, expr: Expr, block: Obj)(
     implicit val pctx: ParseContext)
     extends TagNode {
-  override def render()(implicit ctx: Context): Try[String] = {
-    val iterable: Try[List[_]] = expr.eval().flatMap {
-      case ListValue(l) => Success(l)
+  override def render()(implicit ctx: Context): Validated[String] = {
+    val iterable: Validated[List[_]] = expr.eval().flatMap {
+      case ListValue(l) => Result.valid(l)
       case _ => fail(InvalidIterable(expr))
     }
-    Error
-      .all(iterable) { iterable =>
-        val renders = iterable.map { v =>
-          implicit val forCtx = Context.createChild(ctx)
-          forCtx.mappings.put(id, Value.create(v))
-          block.render()
-        }
-        Error.all(renders: _*)(r => r).map(_.mkString)
+    iterable.flatMap { iterable =>
+      // For each iteration of the loop, render the body
+      val renders = iterable.map { v =>
+        implicit val forCtx = Context.createChild(ctx)
+        forCtx.mappings.put(id, Value.create(v))
+        block.render()
       }
-      .flatten
+      // If successful, combine the bodies to a single string
+      Result.sequence(renders.toList).map(_.mkString)
+    }
   }
 }
 
@@ -91,18 +91,18 @@ final case class IfTag(condition: Expr,
                        elsifs: List[(Expr, Obj)],
                        elseBlock: Option[Obj])(implicit val pctx: ParseContext)
     extends TagNode {
-  override def render()(implicit ctx: Context): Try[String] = {
-    val condErrors = (condition +: elsifs.collect { case (c, _) => c })
-      .map(_.eval())
-      .collect { case Failure(LiquidFailure(errors)) => errors }
-      .flatten
-    val renderErrors =
-      (elsifs.collect { case (_, b) => b } ++ elseBlock.toList)
-        .map(_.render())
-        .collect { case Failure(LiquidFailure(errors)) => errors }
-        .flatten
-    val allErrors = condErrors ++ renderErrors
-    if (allErrors.size > 0) return Error.fail(allErrors: _*)
+  override def render()(implicit ctx: Context): Validated[String] = {
+    // val condErrors = (condition +: elsifs.collect { case (c, _) => c })
+    //   .map(_.eval())
+    //   .collect { case Failure(LiquidFailure(errors)) => errors }
+    //   .flatten
+    // val renderErrors =
+    //   (elsifs.collect { case (_, b) => b } ++ elseBlock.toList)
+    //     .map(_.render())
+    //     .collect { case Failure(LiquidFailure(errors)) => errors }
+    //     .flatten
+    // val allErrors = condErrors ++ renderErrors
+    // if (allErrors.size > 0) return fail(allErrors: _*)
 
     // TODO: Don't evaluate/render twice
     val cond = condition.eval()
@@ -117,30 +117,28 @@ final case class IfTag(condition: Expr,
     if (cond.get.truthy) render
     else {
       for ((c, block) <- elsifResults) if (c.get.truthy) return block
-      elseResult.getOrElse(Success(""))
+      elseResult.getOrElse(Result.valid(""))
     }
   }
 }
 
 final case class IncludeTag(filename: Expr)(implicit val pctx: ParseContext)
     extends TagNode {
-  override def render()(implicit ctx: Context): Try[String] = {
-    Error
-      .all(filename.eval()) {
-        case StringValue(f) => {
-          val path = Paths.get(ctx.includeDir, f);
-          Liquid.parse(path.toString).flatMap(_.render())
-        }
-        case e => fail(InvalidInclude(this, e))
+  override def render()(implicit ctx: Context): Validated[String] = {
+    filename.eval().flatMap {
+      case StringValue(f) => {
+        val path = Paths.get(ctx.includeDir, f);
+        Liquid.parse(path.toString).flatMap(_.render())
       }
-      .flatten
+      case e => fail(InvalidInclude(this, e))
+    }
   }
 }
 
 final case class RawTag(text: String)(implicit val pctx: ParseContext)
     extends TagNode {
-  override def render()(implicit ctx: Context): Try[String] = {
-    Success(text)
+  override def render()(implicit ctx: Context): Validated[String] = {
+    Result.valid(text)
   }
 }
 
@@ -149,20 +147,21 @@ final case class UnlessTag()(implicit val pctx: ParseContext) extends TagNode
 final case class CustomTag(tag: Tag, args: List[Expr])(
     implicit val pctx: ParseContext)
     extends TagNode {
-  override def render()(implicit ctx: Context): Try[String] = {
-    Error
-      .condenseAll(args.map(_.eval()): _*) { args =>
-        Try {
-          implicit val parent = this
-          tag.render(args)
-        }
-      }
-      .recoverWith {
-        case LiquidFailure(errors) =>
-          Failure(LiquidFailure(Error.imbueFragments(errors)))
-        case NonFatal(e) => fail(UncaughtExceptionError(e))
-        case e => fail(UncaughtExceptionError(e))
-      }
+  override def render()(implicit ctx: Context): Validated[String] = {
+    // val evaledArgs = Result.sequence(args.map(_.eval()))
+    // evaledArgs.flatMap { args =>
+    //   val t =
+    //     implicit val parent = this
+    //     tag.render(args)
+    //     .recoverWith {
+    //       case LiquidFailure(errors) =>
+    //         fail(imbueFragments(errors))
+    //       case NonFatal(e) => fail(UncaughtExceptionError(e))
+    //       case e => fail(UncaughtExceptionError(e))
+    //     }
+    //   Result.fromTry(t)
+    // }
+    succeed("")
   }
 }
 
@@ -170,7 +169,7 @@ final case class CaseTag(switchee: Expr,
                          whens: List[(Expr, Obj)],
                          els: Option[Obj])(implicit val pctx: ParseContext)
     extends TagNode {
-  override def render()(implicit ctx: Context): Try[String] = {
+  override def render()(implicit ctx: Context): Validated[String] = {
     val condErrors = (switchee +: whens.collect { case (c, _) => c })
       .map(_.eval())
       .collect { case Failure(LiquidFailure(errors)) => errors }
@@ -192,6 +191,6 @@ final case class CaseTag(switchee: Expr,
     val elseRender = els.map(_.render())
 
     for ((c, block) <- whenRenders) if (c.get == s.get) return block
-    elseRender.getOrElse(Success(""))
+    elseRender.getOrElse(Result.valid(""))
   }
 }

--- a/app/src/main/scala/vlthr/tee/objects.scala
+++ b/app/src/main/scala/vlthr/tee/objects.scala
@@ -93,7 +93,7 @@ final case class IfTag(condition: Expr,
     extends TagNode {
   override def render()(implicit ctx: Context): Validated[String] = {
     val condEval = condition.eval()
-    val thenEval = condition.render()
+    val thenEval = thenBlock.render()
     val elsifEvals = Result.sequence(elsifs.map {
       case (cond, body) => cond.eval() zip body.render()
     })

--- a/app/src/main/scala/vlthr/tee/objects.scala
+++ b/app/src/main/scala/vlthr/tee/objects.scala
@@ -101,8 +101,8 @@ final case class IfTag(condition: Expr,
       .map(_.render())
       .map(r => r.map(s => Some(s)))
       .getOrElse(valid(None))
-    (condEval zip thenEval zip elsifEvals zip elseEval) map {
-      case (((c, t), eis), e) =>
+    (condEval and thenEval and elsifEvals and elseEval) {
+      case (c, t, eis, e) =>
         // Join all of the ifs to a (condition, body) form and find the first that matches
         (((c, t) +: eis) ++ e.map(r => (BooleanValue(true), r)).toList)
           .find { case (cond, body) => cond.truthy }
@@ -170,8 +170,8 @@ final case class CaseTag(switchee: Expr,
       .map(_.render())
       .map(r => r.map(s => Some(s)))
       .getOrElse(valid(None))
-    (switcheeEval zip whenEvals zip elseEval) map {
-      case ((s, ws), e) =>
+    (switcheeEval and whenEvals and elseEval) {
+      case (s, ws, e) =>
         // Add else clause to the end of the when cases, guaranteed to match the switchee
         (ws ++ e.map(r => (s, r)).toList)
           .find { case (comparison, body) => comparison == s }

--- a/app/src/main/scala/vlthr/tee/objects.scala
+++ b/app/src/main/scala/vlthr/tee/objects.scala
@@ -108,7 +108,9 @@ final case class IfTag(condition: Expr,
     val cond = condition.eval()
     val render = thenBlock.render()
 
-    val elsifResults = elsifs.map { case (c, block) => (c.eval(), block.render()) }
+    val elsifResults = elsifs.map {
+      case (c, block) => (c.eval(), block.render())
+    }
 
     val elseResult = elseBlock.map(_.render())
 
@@ -183,7 +185,9 @@ final case class CaseTag(switchee: Expr,
 
     val s = switchee.eval()
 
-    val whenRenders = whens.map { case (c, block) => (c.eval(), block.render()) }
+    val whenRenders = whens.map {
+      case (c, block) => (c.eval(), block.render())
+    }
 
     val elseRender = els.map(_.render())
 

--- a/app/src/main/scala/vlthr/tee/objects.scala
+++ b/app/src/main/scala/vlthr/tee/objects.scala
@@ -100,7 +100,7 @@ final case class IfTag(condition: Expr,
     val elseEval: Validated[Option[String]] = elseBlock
       .map(_.render())
       .map(r => r.map(s => Some(s)))
-      .getOrElse(succeed(None))
+      .getOrElse(valid(None))
     (condEval zip thenEval zip elsifEvals zip elseEval) map {
       case (((c, t), eis), e) =>
         // Join all of the ifs to a (condition, body) form and find the first that matches
@@ -151,7 +151,7 @@ final case class CustomTag(tag: Tag, args: List[Expr])(
     //     }
     //   Result.fromTry(t)
     // }
-    succeed("")
+    valid("")
   }
 }
 
@@ -169,7 +169,7 @@ final case class CaseTag(switchee: Expr,
     val elseEval: Validated[Option[String]] = els
       .map(_.render())
       .map(r => r.map(s => Some(s)))
-      .getOrElse(succeed(None))
+      .getOrElse(valid(None))
     (switcheeEval zip whenEvals zip elseEval) map {
       case ((s, ws), e) =>
         // Add else clause to the end of the when cases, guaranteed to match the switchee

--- a/app/src/main/scala/vlthr/tee/parser.scala
+++ b/app/src/main/scala/vlthr/tee/parser.scala
@@ -67,9 +67,11 @@ object Liquid {
     parser.addErrorListener(errors);
     val tree = parser.template()
     val result = tree.accept(new LiquidNodeVisitor(file))
-    if (errors.errors.size != 0)
-      Result.invalids(validation.NonEmptyVector(errors.errors.toList: _*))
-    else Result.valid(result)
+    if (errors.errors.size != 0) {
+      val (firstError, rest) = errors.errors.toList.splitAt(1)
+      Result.invalids(
+        validation.NonEmptyVector(firstError.head, rest.toVector))
+    } else Result.valid(result)
   }
 
   def parse(path: String)(implicit ctx: Context): Validated[Obj] =

--- a/app/src/main/scala/vlthr/tee/parser.scala
+++ b/app/src/main/scala/vlthr/tee/parser.scala
@@ -11,6 +11,7 @@ import vlthr.tee.filters._
 import vlthr.tee.util.Util
 import scala.util.{Success, Failure, Try}
 import validation.Result
+import shapeless._
 
 object Liquid {
   def makeContext(c: ParserRuleContext, template: SourceFile) = {

--- a/app/src/main/scala/vlthr/tee/typetraits.scala
+++ b/app/src/main/scala/vlthr/tee/typetraits.scala
@@ -1,5 +1,6 @@
 package vlthr.tee.typetraits
-import vlthr.tee.core.Error._
+import vlthr.tee.core.Errors._
+import validation.Result
 import vlthr.tee.core._
 
 package object TypeTraits {

--- a/app/src/main/scala/vlthr/tee/util/util.scala
+++ b/app/src/main/scala/vlthr/tee/util/util.scala
@@ -38,6 +38,7 @@ object Util {
       case BooleanValue(b) => b.asInstanceOf[Object]
       case IntValue(i) => i.asInstanceOf[Object]
       case StringValue(s) => s.asInstanceOf[Object]
+      case NullValue() => null
     }
   }
 

--- a/app/src/main/scala/vlthr/tee/util/util.scala
+++ b/app/src/main/scala/vlthr/tee/util/util.scala
@@ -63,4 +63,11 @@ object Util {
       .asJava
       .asInstanceOf[java.util.Map[String, Object]]
   }
+  def getStackTrace(e: Throwable) = {
+    import java.io.{StringWriter, PrintWriter}
+    val sw = new StringWriter()
+    val pw = new PrintWriter(sw)
+    e.printStackTrace(pw)
+    sw.toString()
+  }
 }

--- a/app/src/test/scala/vlthr/tee/parser/FileTests.scala
+++ b/app/src/test/scala/vlthr/tee/parser/FileTests.scala
@@ -33,7 +33,8 @@ class FileTests(file: SourceFile) {
     "listOfLists" -> List(List(1)),
     "list" -> List(1)
   )
-  implicit val ctx: Context = Context.createNew()
+  implicit val ctx: Context = Context
+    .createNew()
     .withParams(environment.map {
       case (k: String, v: Object) => (k, Value.create(v))
     })

--- a/app/src/test/scala/vlthr/tee/parser/FileTests.scala
+++ b/app/src/test/scala/vlthr/tee/parser/FileTests.scala
@@ -49,14 +49,14 @@ class FileTests(file: SourceFile) {
   @Test def testRender() = {
     fileTest(".render") { f =>
       Liquid.render(f.path, environment, includeDir) match {
-        case Success(output) => output
+        case Result.valid(output) => output
         case Failure(f) => f.toString
       }
     }
   }
 
   // @Test def testMatchesLiqp(): Unit = {
-  //   Assume.assumeTrue(result.isSuccess)
+  //   Assume.assumeTrue(result.isValid)
   //   val actual = result.get.render
   //   if (actual.isFailure) return ()
 

--- a/app/src/test/scala/vlthr/tee/parser/FileTests.scala
+++ b/app/src/test/scala/vlthr/tee/parser/FileTests.scala
@@ -49,7 +49,7 @@ class FileTests(file: SourceFile) {
   @Test def testRender() = {
     fileTest(".render") { f =>
       Liquid.render(f.path, environment, includeDir) match {
-        case Result.valid(output) => output
+        case Success(output) => output
         case Failure(f) => f.toString
       }
     }

--- a/app/src/test/scala/vlthr/tee/parser/ParserSpec.scala
+++ b/app/src/test/scala/vlthr/tee/parser/ParserSpec.scala
@@ -98,15 +98,6 @@ class ParserTests {
     }
   }
 
-  @Ignore
-  @Test def shouldWorkOnAllDottyDocTags() = {
-    val source = Source.fromURL(getClass.getResource("/tags.txt"))
-    val (successes, failures) =
-      source.getLines.map(l => Try(Liquid.parseNode(l))).partition(_.isValid)
-    println(failures)
-    assertEquals(0, failures.size)
-  }
-
   @Test def parseIndexing() = {
     val input = "{{ a[b][c] }}"
     assertParsed(input) {

--- a/app/src/test/scala/vlthr/tee/parser/ParserSpec.scala
+++ b/app/src/test/scala/vlthr/tee/parser/ParserSpec.scala
@@ -102,7 +102,7 @@ class ParserTests {
   @Test def shouldWorkOnAllDottyDocTags() = {
     val source = Source.fromURL(getClass.getResource("/tags.txt"))
     val (successes, failures) =
-      source.getLines.map(l => Try(Liquid.parseNode(l))).partition(_.isSuccess)
+      source.getLines.map(l => Try(Liquid.parseNode(l))).partition(_.isValid)
     println(failures)
     assertEquals(0, failures.size)
   }

--- a/app/src/test/scala/vlthr/tee/parser/RenderTests.scala
+++ b/app/src/test/scala/vlthr/tee/parser/RenderTests.scala
@@ -30,7 +30,8 @@ class RenderTests {
     "listOfLists" -> List(List(1)),
     "list" -> List(1)
   )
-  implicit val ctx: Context = Context.createNew()
+  implicit val ctx: Context = Context
+    .createNew()
     .withParams(environment.map {
       case (k: String, v: Object) => (k, Value.create(v))
     })
@@ -65,16 +66,17 @@ class RenderTests {
     import vlthr.tee.filters._
     import shapeless._
     import ValueTypeables._
+    case class F1KwArgs(x: Option[IntValue])
     case class F1() extends NFilter {
       type Args = IntValue :: StringValue :: HNil
       type OptArgs = HNil
-      type KwArgs = HNil
+      type KwArgs = F1KwArgs
       def filter(args: Args, optArgs: OptArgs, kwArgs: KwArgs) = {
         Success(args.head)
       }
     }
     val filter = F1()
-    filter(IntValue(1) :: StringValue("a") :: Nil) match {
+    filter(IntValue(1) :: StringValue("a") :: Nil, Map("x" -> IntValue(1))) match {
       case Success(output) => assertEquals(IntValue(1), output)
       case Failure(f) => fail("Filter could not render.")
     }

--- a/app/src/test/scala/vlthr/tee/parser/RenderTests.scala
+++ b/app/src/test/scala/vlthr/tee/parser/RenderTests.scala
@@ -46,17 +46,17 @@ class RenderTests {
         with OptKwArgs("limit" -> ValueType.Integer) {
       def name = "customFilter"
       def filter(input: Value, args: List[Value], kwargs: Map[String, Value])(
-          implicit ctx: Context): Try[Value] = {
+          implicit ctx: Context): Validated[Value] = {
         val a = args(0).asInstanceOf[IntValue].v
         val b = args(1).asInstanceOf[IntValue].v
         val c = kwargs("c").asInstanceOf[IntValue].v
-        Success(IntValue(a + b + c))
+        Valid(IntValue(a + b + c))
       }
     }
     val body = """{{ 1 | customFilter: 1, 1 c: 1 }}"""
     implicit val newCtx: Context = ctx.withFilter(CustomFilter())
     Liquid.renderString(body, environment, includeDir, ctx = Some(newCtx)) match {
-      case Success(output) => assertEquals("3", output)
+      case Result.valid(output) => assertEquals("3", output)
       case Failure(f) => fail("Custom filter could not render.")
     }
     ()
@@ -71,12 +71,12 @@ class RenderTests {
       type Args = IntValue :: StringValue :: HNil
       type OptArgs = IntValue :: HNil
       def filter(args: Args, optArgs: OptArgs) = {
-        Success(args.head)
+        Result.valid(args.head)
       }
     }
     val filter = F1()
     filter(IntValue(1) :: StringValue("a") :: Nil) match {
-      case Success(output) => assertEquals(IntValue(1), output)
+      case Result.valid(output) => assertEquals(IntValue(1), output)
       case Failure(f) => fail("Filter could not render.")
     }
     ()

--- a/app/src/test/scala/vlthr/tee/parser/RenderTests.scala
+++ b/app/src/test/scala/vlthr/tee/parser/RenderTests.scala
@@ -67,23 +67,17 @@ class RenderTests {
   @Test def testHListFilter() = {
     import vlthr.tee.filters._
     import shapeless._
-    case class F1KwArgs(x: Option[IntValue])
-    case class F1() extends Filter {
-      def name = "F1"
-      type Input = IntValue :+: CNil
-      type Args = IntValue :: StringValue :: HNil
-      type OptArgs = IntValue :: HNil
-      def filter(input: Input, args: Args, optArgs: OptArgs)(
-          implicit ctx: Context) = {
-        Result.valid(args.head)
-      }
-    }
-    val filter = F1()
-    filter(IntValue(1), IntValue(1) :: StringValue("a") :: Nil) match {
-      case Valid(output) => assertEquals(IntValue(1), output)
-      case Invalid(f) => fail("Filter could not render.")
-      case Invalids(f) => fail("Filter could not render.")
-    }
+    // case class F1KwArgs(x: Option[IntValue])
+    // val f1 = Filter[StringValue, StringValue :: HNil, Empty]("f1") { (ctx, filter, input, args, optArgs) =>
+    //   val pattern = args.head.get
+    //   val stringToSplit = input.get
+    //   Result.valid(Value.create(stringToSplit.split(pattern).toList))
+    // }
+    // f1(IntValue(1), IntValue(1) :: StringValue("a") :: Nil) match {
+    //   case Valid(output) => assertEquals(IntValue(1), output)
+    //   case Invalid(f) => fail("Filter could not render.")
+    //   case Invalids(f) => fail("Filter could not render.")
+    // }
     ()
   }
 }

--- a/app/src/test/scala/vlthr/tee/parser/RenderTests.scala
+++ b/app/src/test/scala/vlthr/tee/parser/RenderTests.scala
@@ -70,14 +70,16 @@ class RenderTests {
     case class F1KwArgs(x: Option[IntValue])
     case class F1() extends Filter {
       def name = "F1"
+      type Input = IntValue :+: CNil
       type Args = IntValue :: StringValue :: HNil
       type OptArgs = IntValue :: HNil
-      def filter(args: Args, optArgs: OptArgs)(implicit ctx: Context) = {
+      def filter(input: Input, args: Args, optArgs: OptArgs)(
+          implicit ctx: Context) = {
         Result.valid(args.head)
       }
     }
     val filter = F1()
-    filter(IntValue(1) :: StringValue("a") :: Nil) match {
+    filter(IntValue(1), IntValue(1) :: StringValue("a") :: Nil) match {
       case Valid(output) => assertEquals(IntValue(1), output)
       case Invalid(f) => fail("Filter could not render.")
       case Invalids(f) => fail("Filter could not render.")

--- a/app/src/test/scala/vlthr/tee/parser/RenderTests.scala
+++ b/app/src/test/scala/vlthr/tee/parser/RenderTests.scala
@@ -69,14 +69,13 @@ class RenderTests {
     case class F1KwArgs(x: Option[IntValue])
     case class F1() extends NFilter {
       type Args = IntValue :: StringValue :: HNil
-      type OptArgs = HNil
-      type KwArgs = F1KwArgs
-      def filter(args: Args, optArgs: OptArgs, kwArgs: KwArgs) = {
+      type OptArgs = IntValue :: HNil
+      def filter(args: Args, optArgs: OptArgs) = {
         Success(args.head)
       }
     }
     val filter = F1()
-    filter(IntValue(1) :: StringValue("a") :: Nil, Map("x" -> IntValue(1))) match {
+    filter(IntValue(1) :: StringValue("a") :: Nil) match {
       case Success(output) => assertEquals(IntValue(1), output)
       case Failure(f) => fail("Filter could not render.")
     }

--- a/app/src/test/scala/vlthr/tee/parser/RenderTests.scala
+++ b/app/src/test/scala/vlthr/tee/parser/RenderTests.scala
@@ -60,4 +60,22 @@ class RenderTests {
     }
     ()
   }
+
+  @Test def testHListFilter() = {
+    import vlthr.tee.filters._
+    import shapeless._
+    import ValueTypeables._
+    case class F1() extends NFilter {
+      type Args = IntValue :: StringValue :: HNil
+      def filter(args: Args) = {
+        Success(args.head)
+      }
+    }
+    val filter = F1()
+    filter(IntValue(1) :: StringValue("a") :: Nil) match {
+      case Success(output) => assertEquals(IntValue(1), output)
+      case Failure(f) => fail("Filter could not render.")
+    }
+    ()
+  }
 }

--- a/app/src/test/scala/vlthr/tee/parser/RenderTests.scala
+++ b/app/src/test/scala/vlthr/tee/parser/RenderTests.scala
@@ -67,7 +67,9 @@ class RenderTests {
     import ValueTypeables._
     case class F1() extends NFilter {
       type Args = IntValue :: StringValue :: HNil
-      def filter(args: Args) = {
+      type OptArgs = HNil
+      type KwArgs = HNil
+      def filter(args: Args, optArgs: OptArgs, kwArgs: KwArgs) = {
         Success(args.head)
       }
     }

--- a/app/src/test/scala/vlthr/tee/parser/RenderTests.scala
+++ b/app/src/test/scala/vlthr/tee/parser/RenderTests.scala
@@ -39,45 +39,21 @@ class RenderTests {
     })
     .withIncludeDir(includeDir)
 
-  // @Test def testCustomFilter() = {
-  //   case class CustomFilter()
-  //       extends Filter
-  //       with InputType(ValueType.Integer)
-  //       with FixedArgs(ValueType.Integer)
-  //       with FixedOptArgs(ValueType.Integer)
-  //       with OptKwArgs("limit" -> ValueType.Integer) {
-  //     def name = "customFilter"
-  //     def filter(input: Value, args: List[Value], kwargs: Map[String, Value])(
-  //         implicit ctx: Context): Validated[Value] = {
-  //       val a = args(0).asInstanceOf[IntValue].v
-  //       val b = args(1).asInstanceOf[IntValue].v
-  //       val c = kwargs("c").asInstanceOf[IntValue].v
-  //       Valid(IntValue(a + b + c))
-  //     }
-  //   }
-  //   val body = """{{ 1 | customFilter: 1, 1 c: 1 }}"""
-  //   implicit val newCtx: Context = ctx.withFilter(CustomFilter())
-  //   Liquid.renderString(body, environment, includeDir, ctx = Some(newCtx)) match {
-  //     case Result.valid(output) => assertEquals("3", output)
-  //     case Failure(f) => fail("Custom filter could not render.")
-  //   }
-  //   ()
-  // }
-
   @Test def testHListFilter() = {
-    import vlthr.tee.filters._
     import shapeless._
-    // case class F1KwArgs(x: Option[IntValue])
-    // val f1 = Filter[StringValue, StringValue :: HNil, Empty]("f1") { (ctx, filter, input, args, optArgs) =>
-    //   val pattern = args.head.get
-    //   val stringToSplit = input.get
-    //   Result.valid(Value.create(stringToSplit.split(pattern).toList))
-    // }
-    // f1(IntValue(1), IntValue(1) :: StringValue("a") :: Nil) match {
-    //   case Valid(output) => assertEquals(IntValue(1), output)
-    //   case Invalid(f) => fail("Filter could not render.")
-    //   case Invalids(f) => fail("Filter could not render.")
-    // }
+    import vlthr.tee.filters._
+    import vlthr.tee.core.Value._
+    val f1 = Filter[IntValue, StringValue :: HNil, Empty]("f1") {
+      (ctx, filter, input, args, optArgs) =>
+        val pattern = args.head.get
+        val n = input.get
+        Result.valid(StringValue(s"$n, $pattern"))
+    }
+    f1(IntValue(1), StringValue("a") :: Nil) match {
+      case Valid(output) => assertEquals(StringValue("1, a"), output)
+      case Invalid(f) => fail("Filter could not render.")
+      case Invalids(f) => fail("Filter could not render.")
+    }
     ()
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,8 @@ lazy val templatingSettings = antlr4Settings ++ Seq(
     "com.vladsch.flexmark" % "flexmark-ext-emoji" % "0.11.1",
     "com.vladsch.flexmark" % "flexmark-ext-gfm-strikethrough" % "0.11.1",
     "com.vladsch.flexmark" % "flexmark-ext-yaml-front-matter" % "0.11.1",
-    "nl.big-o" % "liqp" % "0.7.0"
+    "nl.big-o" % "liqp" % "0.7.0",
+    ("com.chuusai" %% "shapeless" % "2.3.2").withDottyCompat
   ),
   antlr4GenListener in Antlr4 := true,
   antlr4GenVisitor in Antlr4 := true,

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,8 @@ lazy val templatingSettings = antlr4Settings ++ Seq(
     "com.vladsch.flexmark" % "flexmark-ext-gfm-strikethrough" % "0.11.1",
     "com.vladsch.flexmark" % "flexmark-ext-yaml-front-matter" % "0.11.1",
     "nl.big-o" % "liqp" % "0.7.0",
-    ("com.chuusai" %% "shapeless" % "2.3.2").withDottyCompat
+    ("com.chuusai" %% "shapeless" % "2.3.2").withDottyCompat,
+    ("de.knutwalker" %% "validation" % "0.2.0").withDottyCompat
   ),
   antlr4GenListener in Antlr4 := true,
   antlr4GenVisitor in Antlr4 := true,


### PR DESCRIPTION
Replacing the type-trait system for providing type checking to filters, the new filter implementation provides a type safe, concise, and DRY (unlike the previous implementation) way to define new filters - even in user provided code. While the system internally relies on a fair bit of typeclass juggling, the only part of that complexity that is exposed to the user is the HList syntax used for the argument and optional argument types.
```scala 
// Definition of a new filter of the form Filter[InputType, ArgType, OptionalArgType]
val remove: Filter = Filter[StringValue, StringValue :: HNil, HNil]("remove") {
    (ctx, filter, input, args, optArgs) =>
      val pattern = args.head.get
      succeed(StringValue(input.get.replace(pattern, "")))
  }
```
Filter objects have the following interface:
```scala
  abstract trait Filter extends Extension {
    type Input
    type Args <: HList
    type OptArgs <: HList
    def name: String
    def filter(input: Input, args: Args, optArgs: OptArgs)(
        implicit ctx: Context): ValidatedFragment[Value]
    def apply(input: Value, allArgs: List[Value])(
        implicit ctx: Context): ValidatedFragment[Value]
  }
```
The `apply` method is called when rendering the AST and passes unspecified `Value` objects that have not been type checked or validated in any way. Once passed to `apply`, the filter object applies some basic validation to the inputs and arguments by checking the number of arguments passed, and attempting to cast the input/args into the types contained in the type variables Input, Args, and OptArgs respectively. Since this uses the `Typeable[T]` type class, this can be done generically for all filters without running into problems with type erasure.

If all parameters are castable to the expected types, they are passed along to the object's `filter` method where they can be used safely. If the filter requires additional validation, that can be done inside the filter method.

Both `apply` and `filter` return a ValidatedFragment[Value], which is a type alias for `Result[ErrorFragment, Value]`, which is essentially an `Either` with some additional quality of life features that make it easier to collect multiple errors. The reason the error type is `ErrorFragment` rather than `Error` is that each Error contains information about the source code context where it originated from, but since filters objects are independent of the AST they don't carry any such context information. Instead, ErrorFragments are imbued with context higher up in the chain by the AST node that evaluates the filter.
 
If a filter is defined for multiple input types, its type can be given using Dotty union types, e.g. `IntValue | StringValue`. The major caveat here is that I have not been able to get Typeable derivation working for union types yet, so for such filters to work right now you need to define Typeable for each union type.

```scala
  /** Temporary fix for implicits not being created for union types
    */
  implicit val intStrTypeable: Typeable[IntValue | StringValue] =
    new Typeable[IntValue | StringValue] {
      def cast(t: Any): Option[IntValue | StringValue] = t match {
        case v: IntValue => Some(v)
        case v: StringValue => Some(v)
        case _ => None
      }

      def describe: String = s"BooleanValue"
    }

  /** Not working
    */
  implicit def unionTypeable[A, B](implicit aType: Typeable[A], bType: Typeable[B]): Typeable[A | B] = new Typeable[A | B] {
      def cast(t: Any): Option[A | B] = aType.cast(t).orElse(bType.cast(t))

      def describe: String = s"${aType.describe} | ${bType.describe}"
    }
```
Additionally, Dotty runs into a compiler error if a filter is defined with both `Args` and `OptArgs` equal to `HNil`:
```
[info] exception occurred while compiling /home/von/bb/dottydoc-templating/app/src/main/scala/vlthr/tee/filters.scala
java.lang.AssertionError: assertion failed
        at scala.Predef$.assert(Predef.scala:156)
        at dotty.tools.dotc.core.OrderingConstraint.add(OrderingConstraint.scala:284)
        at dotty.tools.dotc.core.OrderingConstraint.add(OrderingConstraint.scala:283)
        at dotty.tools.dotc.core.ConstraintHandling.addToConstraint(ConstraintHandling.scala:319)
...
```
This is due to the `Filter$.apply` factory method requiring two implicit `FromTraversable[T]` type classes - one for each of Args/OptArgs. Normally, shapeless code would wrap one of these into a `Lazy[FromTraversable[T]]`, but `Lazy` relies on old-style macros and as such does not work in dotty.

This is currently being worked around by using another factory method to create filters that don't use any optional arguments (which is almost all of the standard set):
```scala
  val last = Filter.noOptArgs[ListValue | StringValue, Empty]("last") {
    (ctx, filter, input, args, optArgs) =>
      input match {
        case StringValue(v) => succeed(StringValue("" + v.last))
        case ListValue(v) => succeed(v.last)
      }
  }
```
Finally, keyword arguments have been left out entirely from the current implementation - also due to `Lazy` not working. Once that is addressed, keyword args can be added by defining a case class as a fourth type parameter.

@felixmulder - just to keep you updated